### PR TITLE
Add build watch for better dev experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ gradle bootRun
 
 Visit the application at <http://localhost:8080/>
 
+## Development: Rebuild On Changes
+
+Run the compiler in continuous mode to automatically rebuild the app on changes. This should make development faster since developers will not have to manually stop and restart the application for every change.
+
+Start the app in one terminal (keep it running):
+
+```bash
+gradle bootRun
+```
+
+In another terminal, run Gradle in continuous mode to rebuild classes when sources change
+
+```bash
+gradle -t classes
+```
+
 ## Testing
 
 Test with VS Code REST Client using api.http.

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
   implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+  developmentOnly 'org.springframework.boot:spring-boot-devtools'
   runtimeOnly 'org.postgresql:postgresql'
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,5 +9,7 @@ spring:
     open-in-view: false
     properties:
       hibernate.jdbc.time_zone: UTC
+  thymeleaf:
+    cache: false
 server:
   port: 8080


### PR DESCRIPTION
Frontend development is really annoying with manually restarting the application to test each change. This should make development easier for everyone, not just for the frontend.